### PR TITLE
footerの位置が常に画面下に位置するようにした

### DIFF
--- a/next.js13-tailwindcss-first-blog/src/app/layout.tsx
+++ b/next.js13-tailwindcss-first-blog/src/app/layout.tsx
@@ -18,9 +18,13 @@ export default function RootLayout({
   return (
     <html lang="ja">
       <body className="container mx-auto bg-slate-700 text-slate-50">
-        <Header />
-        <Suspense fallback={<Loading />}>{children}</Suspense>
-        <Footer />
+        <div className="flex flex-col min-h-screen">
+          <Header />
+          <main className="flex-grow">
+            <Suspense fallback={<Loading />}>{children}</Suspense>
+          </main>
+          <Footer />
+        </div>
       </body>
     </html>
   );


### PR DESCRIPTION
```
<div className="**flex flex-col** min-h-screen">
          <Header />
          <main className="**flex-grow**">
            <Suspense fallback={<Loading />}>{children}</Suspense>
          </main>
          <Footer />
 </div>
```
flex-growによって、もし画面に余白ができた場合それを引き伸ばす。
その結果、footerはいつでも画面の下にくるようになる。